### PR TITLE
Add Ctx.SetMinProtoVersion and Ctx.SetMaxProtoVersion wrappers

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -362,6 +362,32 @@ func (c *Ctx) LoadVerifyLocations(ca_file string, ca_path string) error {
 	return nil
 }
 
+type Version int
+
+const (
+	SSL3_VERSION Version = C.SSL3_VERSION
+	TLS1_VERSION Version = C.TLS1_VERSION
+	TLS1_1_VERSION Version = C.TLS1_1_VERSION
+	TLS1_2_VERSION Version = C.TLS1_2_VERSION
+	TLS1_3_VERSION Version = C.TLS1_3_VERSION
+	DTLS1_VERSION Version = C.DTLS1_VERSION
+	DTLS1_2_VERSION Version = C.DTLS1_2_VERSION
+)
+
+// SetMinProtoVersion sets the minimum supported protocol version for the Ctx.
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_min_proto_version.html
+func (c *Ctx) SetMinProtoVersion(version Version) bool {
+	return C.X_SSL_CTX_set_min_proto_version(
+		c.ctx, C.int(version)) == 1
+}
+
+// SetMaxProtoVersion sets the maximum supported protocol version for the Ctx.
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_max_proto_version.html
+func (c *Ctx) SetMaxProtoVersion(version Version) bool {
+	return C.X_SSL_CTX_set_max_proto_version(
+		c.ctx, C.int(version)) == 1
+}
+
 type Options int
 
 const (

--- a/shim.c
+++ b/shim.c
@@ -475,6 +475,14 @@ int X_SSL_CTX_new_index() {
 	return SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 }
 
+int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version) {
+	return SSL_CTX_set_min_proto_version(ctx, version);
+}
+
+int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version) {
+	return SSL_CTX_set_max_proto_version(ctx, version);
+}
+
 long X_SSL_CTX_set_options(SSL_CTX* ctx, long options) {
 	return SSL_CTX_set_options(ctx, options);
 }

--- a/shim.h
+++ b/shim.h
@@ -67,6 +67,8 @@ extern int X_SSL_verify_cb(int ok, X509_STORE_CTX* store);
 
 /* SSL_CTX methods */
 extern int X_SSL_CTX_new_index();
+extern int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
+extern int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
 extern long X_SSL_CTX_set_options(SSL_CTX* ctx, long options);
 extern long X_SSL_CTX_clear_options(SSL_CTX* ctx, long options);
 extern long X_SSL_CTX_get_options(SSL_CTX* ctx);


### PR DESCRIPTION
- Ctx.SetMinProtoVersion wraps SSL_CTX_set_min_proto_version
- Ctx.SetMaxProtoVersion wraps SSL_CTX_set_max_proto_version