### PR TITLE
Fix build on CentOS 7

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -476,11 +476,19 @@ int X_SSL_CTX_new_index() {
 }
 
 int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version) {
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
 	return SSL_CTX_set_min_proto_version(ctx, version);
+#else
+	return 0;
+#endif
 }
 
 int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version) {
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
 	return SSL_CTX_set_max_proto_version(ctx, version);
+#else
+	return 0;
+#endif
 }
 
 long X_SSL_CTX_set_options(SSL_CTX* ctx, long options) {

--- a/shim.h
+++ b/shim.h
@@ -67,6 +67,9 @@ extern int X_SSL_verify_cb(int ok, X509_STORE_CTX* store);
 
 /* SSL_CTX methods */
 extern int X_SSL_CTX_new_index();
+#ifndef TLS1_3_VERSION
+#define TLS1_3_VERSION 0
+#endif
 extern int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
 extern int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
 extern long X_SSL_CTX_set_options(SSL_CTX* ctx, long options);


### PR DESCRIPTION
CentOS 7 has an old OpenSSL version 1.0.2. We can provide support for it which was broken by our patches.

How-to reproduce the problems:

1. Download and install OpenSSL 1.0.2:

```bash
cd /tmp/
wget https://www.openssl.org/source/openssl-1.0.2l.tar.gz
tar -xvf openssl-1.0.2l.tar.gz
cd openssl-1.0.2l/
./config --prefix=/tmp/openssl/ && make && make install
```

2. Configure CGO_CFLAGS && CGO_LDFLAGS with the OpenSSL prefix:

```bash
export CGO_LDFLAGS="-L/tmp/openssl/lib"
export CGO_CFLAGS="-Wno-deprecated-declarations -I/tmp/openssl/include"
```

3. Try to build tests:

```bash
go test -c .
```