### PR TITLE
Fix static build on macOS

### DIFF
--- a/build.go
+++ b/build.go
@@ -19,7 +19,7 @@ package openssl
 
 // #cgo linux windows freebsd openbsd solaris pkg-config: libssl libcrypto
 // #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build.go
+++ b/build.go
@@ -19,7 +19,11 @@ package openssl
 
 // #cgo linux windows freebsd openbsd solaris pkg-config: libssl libcrypto
 // #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin,386 CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,386 LDFLAGS: -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin,amd64 CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build_static.go
+++ b/build_static.go
@@ -19,7 +19,7 @@ package openssl
 
 // #cgo linux windows freebsd openbsd solaris pkg-config: --static libssl libcrypto
 // #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build_static.go
+++ b/build_static.go
@@ -19,7 +19,11 @@ package openssl
 
 // #cgo linux windows freebsd openbsd solaris pkg-config: --static libssl libcrypto
 // #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
+// #cgo darwin,386 CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,386 LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
+// #cgo darwin,amd64 CFLAGS: -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,amd64 LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
+// #cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin,arm64 LDFLAGS: /opt/homebrew/opt/openssl/lib/libcrypto.a /opt/homebrew/opt/openssl/lib/libssl.a
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"


### PR DESCRIPTION
The build tag `openssl_static` does not produce a binary with static linked libcrypto and libssl. The patch fixes it.

Related to https://github.com/tarantool/tt/issues/308

The patch also fix build on macOS with Apple M1

Related to https://github.com/tarantool/go-tarantool/issues/260

How-to test the static build:

```bash
$ go test . -c
$ otool -L go-openssl.test 
go-openssl.test:
	/usr/local/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/local/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.255.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60420.60.24)
$ go test . -c -tags openssl_static
$ otool -L go-openssl.test         
go-openssl.test:
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.255.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60420.60.24)
```