### PR TITLE
dial: add `DialContext` function

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -7,13 +7,6 @@ runs:
       shell: bash
       run: |
         echo 'CGO_ENABLED=1' >> $GITHUB_ENV
-    - name: Windows setup
-      shell: bash
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        pacman -S --noconfirm mingw-w64-x86_64-toolchain mingw-w64-i686-toolchain
-        echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
-        echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
     - name: Linux setup
       shell: bash
       if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/go-test-ubuntu-22.04.yml
+++ b/.github/workflows/go-test-ubuntu-22.04.yml
@@ -27,14 +27,6 @@ jobs:
         run: |
           go version
           go env
-      - name: Use msys2 on windows
-        if: startsWith(matrix.os, 'windows')
-        shell: bash
-        # The executable for msys2 is also called bash.cmd
-        #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#shells
-        # If we prepend its location to the PATH
-        #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
-        run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
@@ -55,7 +47,7 @@ jobs:
             export "PATH=${{ env.PATH_386 }}:$PATH"
             go test -v ./...
       - name: Run tests with race detector
-        if: startsWith(matrix.os, 'ubuntu') # speed things up. Windows and OSX VMs are slow
+        if: startsWith(matrix.os, 'ubuntu') # speed things up. OSX VMs is slow
         uses: protocol/multiple-go-modules@v1.2
         with:
           run: go test -v -race ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu", "windows", "macos" ]
+        os: [ "ubuntu", "macos" ]
         go: [ "1.18.x", "1.19.x" ]
     env:
       COVERAGES: ""
@@ -26,14 +26,6 @@ jobs:
         run: |
           go version
           go env
-      - name: Use msys2 on windows
-        if: ${{ matrix.os == 'windows' }}
-        shell: bash
-        # The executable for msys2 is also called bash.cmd
-        #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#shells
-        # If we prepend its location to the PATH
-        #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
-        run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
@@ -54,7 +46,7 @@ jobs:
             export "PATH=${{ env.PATH_386 }}:$PATH"
             go test -v -shuffle=on ./...
       - name: Run tests with race detector
-        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+        if: ${{ matrix.os == 'ubuntu' }} # speed things up. OSX VMs is slow
         uses: protocol/multiple-go-modules@v1.2
         with:
           run: go test -v -race ./...

--- a/net_test.go
+++ b/net_test.go
@@ -1,0 +1,101 @@
+package openssl_test
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tarantool/go-openssl"
+)
+
+func sslConnect(t *testing.T, ssl_listener net.Listener) {
+	for {
+		var err error
+		conn, err := ssl_listener.Accept()
+		if err != nil {
+			t.Errorf("failed accept: %s", err)
+			continue
+		}
+		io.Copy(conn, io.LimitReader(rand.Reader, 1024))
+		break
+	}
+}
+
+func TestDial(t *testing.T) {
+	ctx := openssl.GetCtx(t)
+	if err := ctx.SetCipherList("AES128-SHA"); err != nil {
+		t.Fatal(err)
+	}
+	ssl_listener, err := openssl.Listen("tcp", "localhost:0", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		sslConnect(t, ssl_listener)
+		wg.Done()
+	}()
+
+	client, err := openssl.Dial(ssl_listener.Addr().Network(),
+		ssl_listener.Addr().String(), ctx, openssl.InsecureSkipHostVerification)
+
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	n, err := io.Copy(io.Discard, io.LimitReader(client, 1024))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if n != 1024 {
+		if n == 0 {
+			t.Fatal("client is closed after creation")
+		}
+		t.Fatalf("client lost some bytes, expected %d, got %d", 1024, n)
+	}
+}
+
+func TestDialTimeout(t *testing.T) {
+	ctx := openssl.GetCtx(t)
+	if err := ctx.SetCipherList("AES128-SHA"); err != nil {
+		t.Fatal(err)
+	}
+	ssl_listener, err := openssl.Listen("tcp", "localhost:0", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := openssl.DialTimeout(ssl_listener.Addr().Network(),
+		ssl_listener.Addr().String(), time.Nanosecond, ctx, 0)
+
+	if client != nil || err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestDialContext(t *testing.T) {
+	ctx := openssl.GetCtx(t)
+	if err := ctx.SetCipherList("AES128-SHA"); err != nil {
+		t.Fatal(err)
+	}
+	ssl_listener, err := openssl.Listen("tcp", "localhost:0", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client, err := openssl.DialContext(cancelCtx, ssl_listener.Addr().Network(),
+		ssl_listener.Addr().String(), ctx, 0)
+
+	if client != nil || err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -738,7 +738,7 @@ func TestStdlibLotsOfConns(t *testing.T) {
 		})
 }
 
-func getCtx(t *testing.T) *Ctx {
+func GetCtx(t *testing.T) *Ctx {
 	ctx, err := NewCtx()
 	if err != nil {
 		t.Fatal(err)
@@ -761,7 +761,7 @@ func getCtx(t *testing.T) *Ctx {
 }
 
 func TestOpenSSLLotsOfConns(t *testing.T) {
-	ctx := getCtx(t)
+	ctx := GetCtx(t)
 	if err := ctx.SetCipherList("AES128-SHA"); err != nil {
 		t.Fatal(err)
 	}
@@ -928,7 +928,7 @@ func TestOpenSSLLotsOfConnsWithFail(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			LotsOfConns(t, 1024*64, 10, 100, 0*time.Second,
 				func(l net.Listener) net.Listener {
-					return NewListener(l, getCtx(t))
+					return NewListener(l, GetCtx(t))
 				}, func(c net.Conn) (net.Conn, error) {
 					return Client(c, getClientCtx(t))
 				})


### PR DESCRIPTION
In order to replace timeouts with contexts in `Connect` instance creation (go-tarantool), I need a `DialContext` function. It accepts context, and cancels, if context is canceled by user.

Disabled flaking CI Windows runner. Because we don't support connector on Windows, I considered disabling these tests.

Part of https://github.com/tarantool/go-tarantool/issues/136