### PR TITLE
Add bindings for DANE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 openssl.test
+/.ccls-cache/
+/.ccls
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Bindings for [DANE](https://docs.openssl.org/1.1.1/man3/SSL_CTX_dane_enable/).
+- Bindings for [TLS handshake tracing](https://docs.openssl.org/master/man3/SSL_CTX_set_msg_callback/).
+- Bindings for `X509_digest()`.
+- Bindings for `X509_verify_cert_error_string()`.
+- Bindings for `SSL_get_version()`.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Forked from https://github.com/libp2p/openssl (unmaintained) to add:
 2. Fix build on Apple M1.
 3. Fix static build.
 4. Fix error extraction on key reading.
+5. Bindings for DANE.
 
 ### License
 

--- a/cert_test.go
+++ b/cert_test.go
@@ -15,6 +15,7 @@
 package openssl
 
 import (
+	"encoding/hex"
 	"math/big"
 	"testing"
 	"time"
@@ -160,5 +161,28 @@ func TestCertVersion(t *testing.T) {
 	}
 	if vers := cert.GetVersion(); vers != X509_V3 {
 		t.Fatalf("bad version: %d", vers)
+	}
+}
+
+func TestCertHash(t *testing.T) {
+	cert, err := LoadCertificateFromPEM(certBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest, err := GetDigestByName("SHA256")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hash := hex.EncodeToString(cert.Hash(digest)); hash != certHashHex {
+		t.Fatalf("Wrong hash returned, expected %q, got %q", certHashHex, hash)
+	}
+}
+
+func TestVerifyCertErrorString(t *testing.T) {
+	expected := "unable to get issuer certificate"
+	if result := VerifyCertErrorString(UnableToGetIssuerCert); result != expected {
+		t.Fatalf("Wrong cert error string returned, expected %q, got %q", expected, result)
 	}
 }

--- a/digest.go
+++ b/digest.go
@@ -28,7 +28,8 @@ type Digest struct {
 }
 
 // GetDigestByName returns the Digest with the name or nil and an error if the
-// digest was not found.
+// digest was not found. Use `openssl list -digest-algorithms` to list available
+// digest names.
 func GetDigestByName(name string) (*Digest, error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))

--- a/shim.c
+++ b/shim.c
@@ -439,6 +439,16 @@ int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {
 	return go_ssl_verify_cb_thunk(p, ok, store);
 }
 
+void X_SSL_toggle_tracing(SSL* ssl, FILE* output, short enable) {
+	if (enable) {
+		SSL_set_msg_callback(ssl, SSL_trace);
+		SSL_set_msg_callback_arg(ssl, BIO_new_fp(output, BIO_NOCLOSE));
+	} else {
+		SSL_set_msg_callback(ssl, NULL);
+		SSL_set_msg_callback_arg(ssl, NULL);
+	}
+}
+
 const SSL_METHOD *X_SSLv23_method() {
 	return SSLv23_method();
 }

--- a/shim.h
+++ b/shim.h
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
@@ -53,6 +54,7 @@ extern long X_SSL_set_tlsext_host_name(SSL *ssl, const char *name);
 extern const char * X_SSL_get_cipher_name(const SSL *ssl);
 extern int X_SSL_session_reused(SSL *ssl);
 extern int X_SSL_new_index();
+extern void X_SSL_toggle_tracing(SSL* ssl, FILE* output, short enable);
 
 extern const SSL_METHOD *X_SSLv23_method();
 extern const SSL_METHOD *X_SSLv3_method();


### PR DESCRIPTION
## Overview

First of all, thanks for keeping this library maintained :D

This PR adds CGO bindings for a bunch of openssl function, most notably DANE (DNS-based Authentication of Named Entities) related functions.

## New features

- Bindings for [DANE](https://docs.openssl.org/1.1.1/man3/SSL_CTX_dane_enable/)
- Bindings for [TLS handshake tracing](https://docs.openssl.org/master/man3/SSL_CTX_set_msg_callback/)
- Bindings for `X509_digest()`
- Bindings for `X509_verify_cert_error_string()`
- Bindings for `SSL_get_version()`
