### PR TITLE
shim: check X509_STORE_CTX_get_ex_data return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Unchecked `X509_STORE_CTX_get_ex_data` return value (#16).
+
 ## [v1.1.0] - 2024-09-02
 
 The release adds more bindings.

--- a/shim.c
+++ b/shim.c
@@ -434,6 +434,10 @@ int X_SSL_new_index() {
 int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {
 	SSL* ssl = (SSL *)X509_STORE_CTX_get_ex_data(store,
 			SSL_get_ex_data_X509_STORE_CTX_idx());
+	if (ssl == NULL) {
+		return 0;
+	}
+
 	void* p = SSL_get_ex_data(ssl, get_ssl_idx());
 	// get the pointer to the go Ctx object and pass it back into the thunk
 	return go_ssl_verify_cb_thunk(p, ok, store);
@@ -557,6 +561,10 @@ long X_SSL_CTX_set_tlsext_servername_callback(
 int X_SSL_CTX_verify_cb(int ok, X509_STORE_CTX* store) {
 	SSL* ssl = (SSL *)X509_STORE_CTX_get_ex_data(store,
 			SSL_get_ex_data_X509_STORE_CTX_idx());
+	if (ssl == NULL) {
+		return 0;
+	}
+
 	SSL_CTX* ssl_ctx = SSL_get_SSL_CTX(ssl);
 	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
 	// get the pointer to the go Ctx object and pass it back into the thunk


### PR DESCRIPTION
Return value of a function 'X509_STORE_CTX_get_ex_data' is dereferenced without checking for NULL, but it is usually checked for this function.