### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+## [v1.2.1] - 2025-01-27
+
+The releases fixes tests on Tarantool Cluster Manager.
+
+### Changed
+
+- stretchr/testify dependency decreased to v1.10.0.
+
 ## [v1.2.0] - 2025-01-21
 
 The release introduces `Close()` method of the Ctx, that

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tarantool/go-openssl
 require (
 	github.com/mattn/go-pointer v0.0.1
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
The releases fixes tests on Tarantool Cluster Manager.

### Changed

- stretchr/testify dependency decreased to v1.10.0.