### PR TITLE
shim: guard SSL_trace usage with OPENSSL_NO_SSL_TRACE check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Guard `SSL_trace` usage with `OPENSSL_NO_SSL_TRACE` check to fix build on
+  OpenSSL configurations without SSL trace support.
+
 ## [v1.2.1] - 2025-01-27
 
 The release fixes tests on Tarantool Cluster Manager.

--- a/shim.c
+++ b/shim.c
@@ -444,6 +444,7 @@ int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {
 }
 
 void X_SSL_toggle_tracing(SSL* ssl, FILE* output, short enable) {
+#ifndef OPENSSL_NO_SSL_TRACE
 	if (enable) {
 		SSL_set_msg_callback(ssl, SSL_trace);
 		SSL_set_msg_callback_arg(ssl, BIO_new_fp(output, BIO_NOCLOSE));
@@ -451,6 +452,7 @@ void X_SSL_toggle_tracing(SSL* ssl, FILE* output, short enable) {
 		SSL_set_msg_callback(ssl, NULL);
 		SSL_set_msg_callback_arg(ssl, NULL);
 	}
+#endif
 }
 
 const SSL_METHOD *X_SSLv23_method() {


### PR DESCRIPTION
Fixes build with OpenSSL v1 where SSL_trace is not available.

Closes #18