### PR TITLE
ctx: add server-side ALPN protocol selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- ctx: `SetServerALPNProtos` for server-side ALPN protocol selection. It
+  registers `SSL_CTX_set_alpn_select_cb` and delegates the match to OpenSSL's
+  `SSL_select_next_proto`, so a server selects and echoes a protocol (e.g. `h2`)
+  from the client's advertised list, which is required for serving standard
+  gRPC/HTTP2 clients. The pre-existing `SetNextProtos` only sets the client-side
+  advertised list and does not select on the server. The list must be non-empty;
+  an empty list is rejected so the server never installs a callback that would
+  abort every ALPN-offering handshake. Works with per-vhost SNI: when the
+  servername callback swaps the `Ctx` via `SetSSLCtx`, selection runs against the
+  swapped-in `Ctx`'s list.
+- ssl: `GetALPNNegotiated` (promoted to `Conn`) returns the protocol selected via
+  ALPN during the handshake, wrapping `SSL_get0_alpn_selected`.
+
 ### Changed
 
 ### Fixed

--- a/alpn.c
+++ b/alpn.c
@@ -1,0 +1,107 @@
+// Copyright (C) 2026. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <openssl/ssl.h>
+#include <openssl/crypto.h>
+#include <string.h>
+
+// Server-side ALPN selection.
+//
+// A Ctx that calls SetServerALPNProtos stores its ordered preference list, in
+// ALPN wire format (a sequence of 1-byte-length-prefixed protocol names), in
+// SSL_CTX ex_data under alpn_protos_idx. The buffer is heap-allocated and owned
+// by OpenSSL: free_alpn_protos runs when the SSL_CTX itself is destroyed, so the
+// list outlives every in-flight handshake that might read it. (Freeing it from a
+// Go finalizer instead would be unsafe: the Go *Ctx can become unreachable while
+// live SSL connections still hold a reference to the underlying SSL_CTX.)
+
+// alpn_list is a ctx-owned server preference list. The length is stored
+// alongside the bytes because SSL_select_next_proto needs server_len and the
+// wire format is not self-delimiting.
+struct alpn_list {
+	unsigned int len;
+	unsigned char data[];
+};
+
+static int alpn_protos_idx = -1;
+
+static void free_alpn_protos(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                             int idx, long argl, void *argp) {
+	OPENSSL_free(ptr);
+}
+
+// X_SSL_CTX_alpn_protos_new_index allocates (once) the SSL_CTX ex_data index
+// used to store each ctx's server ALPN list. Called from Go package init.
+int X_SSL_CTX_alpn_protos_new_index() {
+	if (alpn_protos_idx < 0)
+		alpn_protos_idx =
+		    SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, free_alpn_protos);
+	return alpn_protos_idx;
+}
+
+// X_alpn_select_cb is the server-side ALPN selection callback. It delegates the
+// match to OpenSSL's SSL_select_next_proto against the current SSL_CTX's stored
+// list, recovered from ex_data. SSL_get_SSL_CTX reflects any SNI-driven
+// SSL_set_SSL_CTX swap, so each vhost's own list is used. On no overlap (or an
+// invalid client list) it aborts the handshake with a no_application_protocol
+// alert, as ALPN requires (RFC 7301).
+static int X_alpn_select_cb(SSL *ssl, const unsigned char **out,
+                            unsigned char *outlen, const unsigned char *in,
+                            unsigned int inlen, void *arg) {
+	struct alpn_list *al =
+	    SSL_CTX_get_ex_data(SSL_get_SSL_CTX(ssl), alpn_protos_idx);
+	if (al == NULL)
+		return SSL_TLSEXT_ERR_ALERT_FATAL;
+
+	// On a match SSL_select_next_proto points *out into al->data (the server
+	// list) and favors the server's order; that pointer stays valid because al
+	// lives for the SSL_CTX's lifetime, and OpenSSL copies the selected protocol
+	// immediately after this callback returns.
+	if (SSL_select_next_proto((unsigned char **)out, outlen, al->data, al->len,
+	                          in, inlen) != OPENSSL_NPN_NEGOTIATED) {
+		return SSL_TLSEXT_ERR_ALERT_FATAL;
+	}
+	return SSL_TLSEXT_ERR_OK;
+}
+
+// X_SSL_CTX_set_server_alpn copies protos (wire format, protos_len bytes) into a
+// ctx-owned buffer, replacing and freeing any list from a previous call, and
+// registers the selection callback. Returns 1 on success, 0 on allocation
+// failure.
+int X_SSL_CTX_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                              unsigned int protos_len) {
+	struct alpn_list *al = OPENSSL_malloc(sizeof(*al) + protos_len);
+	if (al == NULL)
+		return 0;
+	al->len = protos_len;
+	memcpy(al->data, protos, protos_len);
+
+	// Install the new list before freeing the old one so the swap is atomic: if
+	// SSL_CTX_set_ex_data fails, the ctx still points at the old (still-valid)
+	// list and we free only the new allocation, leaving the ctx unchanged. On
+	// success we free the previous list; the ex_data free function only runs on
+	// ctx destruction, not on overwrite, and OPENSSL_free(NULL) is a no-op so the
+	// first call is fine too. Freeing before a failed install would leave a
+	// dangling pointer in the ctx (use-after-free at handshake, double-free at
+	// ctx destruction).
+	void *old = SSL_CTX_get_ex_data(ctx, alpn_protos_idx);
+	if (!SSL_CTX_set_ex_data(ctx, alpn_protos_idx, al)) {
+		OPENSSL_free(al);
+		return 0;
+	}
+	OPENSSL_free(old);
+
+	SSL_CTX_set_alpn_select_cb(ctx, X_alpn_select_cb, NULL);
+	return 1;
+}

--- a/alpn_test.go
+++ b/alpn_test.go
@@ -1,0 +1,425 @@
+// Copyright (C) 2026. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// Characterization tests for ALPN negotiation.
+//
+// This package has no ALPN getter (no SSL_get0_alpn_selected binding), so the
+// only way to observe the negotiated protocol is to put a crypto/tls peer on
+// the other end and read its ConnectionState().NegotiatedProtocol.
+//
+// Ctx.SetNextProtos wraps SSL_CTX_set_alpn_protos, the *client*-side ALPN
+// mechanism, while Ctx.SetServerALPNProtos registers SSL_CTX_set_alpn_select_cb,
+// the *server*-side callback that actually selects and echoes a protocol. These
+// tests exercise both directions.
+
+import (
+	"crypto/tls"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// openSSLCtxALPN builds a Ctx configured like OpenSSLConstructor, additionally
+// advertising the given ALPN protocols via SetNextProtos.
+func openSSLCtxALPN(t *testing.T, protos []string) *Ctx {
+	ctx, err := NewCtx()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.SetVerify(VerifyNone, passThruVerify(t))
+	key, err := LoadPrivateKeyFromPEM(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.UsePrivateKey(key); err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadCertificateFromPEM(certBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.UseCertificate(cert); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.SetCipherList("AES128-SHA"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.SetNextProtos(protos); err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
+// stdlibConfigALPN mirrors StdlibConstructor's config plus ALPN protocols.
+func stdlibConfigALPN(t *testing.T, protos []string) *tls.Config {
+	cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true,
+		CipherSuites:       []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+		NextProtos:         protos,
+	}
+}
+
+// handshakeBoth drives both peers' handshakes concurrently and fails on error.
+func handshakeBoth(t *testing.T, server, client HandshakingConn) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() { defer wg.Done(); errs[0] = server.Handshake() }()
+	go func() { defer wg.Done(); errs[1] = client.Handshake() }()
+	wg.Wait()
+	if errs[0] != nil {
+		t.Fatalf("server handshake failed: %v", errs[0])
+	}
+	if errs[1] != nil {
+		t.Fatalf("client handshake failed: %v", errs[1])
+	}
+}
+
+// Control case: stdlib <-> stdlib. Proves the harness and cert setup are sound,
+// and that stdlib server-side ALPN selection works (expected: "h2" both sides).
+func TestALPN_StdlibServer_StdlibClient(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	cfg := stdlibConfigALPN(t, []string{"h2"})
+	server := tls.Server(serverConn, cfg)
+	client := tls.Client(clientConn, cfg)
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	srv := server.ConnectionState().NegotiatedProtocol
+	cli := client.ConnectionState().NegotiatedProtocol
+	t.Logf("stdlib server NegotiatedProtocol=%q, stdlib client NegotiatedProtocol=%q", srv, cli)
+	if srv != "h2" || cli != "h2" {
+		t.Errorf("expected both sides to negotiate h2; got server=%q client=%q", srv, cli)
+	}
+}
+
+// Client side of go-openssl: openssl client <-> stdlib server.
+// SSL_CTX_set_alpn_protos is the client mechanism, so the openssl client should
+// correctly advertise h2 and the stdlib server should select it (expected: "h2").
+func TestALPN_StdlibServer_OpenSSLClient(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	server := tls.Server(serverConn, stdlibConfigALPN(t, []string{"h2"}))
+	clientCtx := openSSLCtxALPN(t, []string{"h2"})
+	client, err := Client(clientConn, clientCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	// Measured on the stdlib server, which reports what it selected from the
+	// client's advertised list.
+	got := server.ConnectionState().NegotiatedProtocol
+	t.Logf("openssl client advertised h2 -> stdlib server NegotiatedProtocol=%q", got)
+	if got != "h2" {
+		t.Errorf("openssl client ALPN advertise broken: stdlib server negotiated %q, want %q", got, "h2")
+	}
+}
+
+// Server side of go-openssl: openssl server <-> stdlib client. This is the
+// gRPC-relevant case. The openssl server calls SetServerALPNProtos(["h2"]),
+// which registers SSL_CTX_set_alpn_select_cb, so it selects and echoes "h2".
+// A standard (gRPC-style) client therefore observes "h2".
+func TestALPN_OpenSSLServer_StdlibClient(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverCtx := openSSLCtxALPN(t, nil)
+	if err := serverCtx.SetServerALPNProtos([]string{"h2"}); err != nil {
+		t.Fatal(err)
+	}
+	server, err := Server(serverConn, serverCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := tls.Client(clientConn, stdlibConfigALPN(t, []string{"h2"}))
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	got := client.ConnectionState().NegotiatedProtocol
+	t.Logf("openssl server SetServerALPNProtos([h2]) + stdlib client offering h2 -> client NegotiatedProtocol=%q", got)
+	if got != "h2" {
+		t.Errorf("server-side ALPN failed: client negotiated %q, want %q", got, "h2")
+	}
+}
+
+// No mutual protocol: the openssl server offers only "h2" while the client
+// offers only "http/1.1". SetServerALPNProtos must abort the handshake with a
+// no_application_protocol alert (RFC 7301), so at least one side errors rather
+// than silently completing without ALPN.
+func TestALPN_OpenSSLServer_NoOverlap(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverCtx := openSSLCtxALPN(t, nil)
+	if err := serverCtx.SetServerALPNProtos([]string{"h2"}); err != nil {
+		t.Fatal(err)
+	}
+	server, err := Server(serverConn, serverCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := tls.Client(clientConn, stdlibConfigALPN(t, []string{"http/1.1"}))
+	defer close_both(server, client)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() { defer wg.Done(); errs[0] = server.Handshake() }()
+	go func() { defer wg.Done(); errs[1] = client.Handshake() }()
+	wg.Wait()
+
+	t.Logf("no-overlap handshake result: server=%v client=%v", errs[0], errs[1])
+	if errs[0] == nil && errs[1] == nil {
+		t.Error("expected the handshake to fail with no ALPN overlap, but both sides succeeded")
+	}
+}
+
+// A multi-entry server preference list must reach SSL_select_next_proto intact.
+// The server offers two protocols but the client offers only "h2", so "h2" is
+// the sole common protocol and must be selected regardless of preference-order
+// semantics. This exercises the multi-entry, ctx-owned server buffer that
+// SetServerALPNProtos hands to OpenSSL.
+func TestALPN_OpenSSLServer_MultiProtoServerList(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverCtx := openSSLCtxALPN(t, nil)
+	if err := serverCtx.SetServerALPNProtos([]string{"h2", "http/1.1"}); err != nil {
+		t.Fatal(err)
+	}
+	server, err := Server(serverConn, serverCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := tls.Client(clientConn, stdlibConfigALPN(t, []string{"h2"}))
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	if got := client.ConnectionState().NegotiatedProtocol; got != "h2" {
+		t.Errorf("client negotiated %q, want %q", got, "h2")
+	}
+	if got := server.GetALPNNegotiated(); got != "h2" {
+		t.Errorf("server GetALPNNegotiated() = %q, want %q", got, "h2")
+	}
+}
+
+// SetServerALPNProtos must reject an empty list. Installing the selection
+// callback with nothing to select would make the server abort every handshake
+// in which the client offers ALPN, turning "no ALPN configured" into a footgun.
+func TestALPN_SetServerALPNProtos_RejectsEmpty(t *testing.T) {
+	ctx, err := NewCtx()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, protos := range [][]string{nil, {}} {
+		if err := ctx.SetServerALPNProtos(protos); err == nil {
+			t.Errorf("SetServerALPNProtos(%#v) = nil; want error for empty list", protos)
+		}
+	}
+}
+
+// SetServerALPNProtos must reject a list containing an out-of-range protocol.
+// The ALPN wire format prefixes each protocol with a single length byte, so a
+// zero-length name is unrepresentable and a name longer than 255 bytes cannot
+// be encoded. Rejecting these up front keeps such a list from ever reaching the
+// selection callback.
+func TestALPN_SetServerALPNProtos_RejectsInvalidProto(t *testing.T) {
+	ctx, err := NewCtx()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string][]string{
+		"empty proto":         {""},
+		"too long proto":      {strings.Repeat("a", 256)},
+		"valid then empty":    {"h2", ""},
+		"valid then too long": {"h2", strings.Repeat("a", 256)},
+	}
+	for name, protos := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ctx.SetServerALPNProtos(protos); err == nil {
+				t.Errorf("SetServerALPNProtos(%#v) = nil; want error for out-of-range proto", protos)
+			}
+		})
+	}
+}
+
+// Multi-vhost SNI: when the servername callback swaps in a different Ctx via
+// SetSSLCtx, ALPN selection must run against the *swapped* Ctx, not the original
+// listening Ctx. OpenSSL fires the servername callback before it performs ALPN
+// selection and reads both the callback and the preference list from the
+// then-current SSL_CTX, so each vhost's own SetServerALPNProtos governs what it
+// negotiates. Each Ctx is configured with a single, distinct protocol, so the
+// negotiated result reveals which Ctx did the selecting regardless of
+// preference-order semantics. This is the case the reviewer was unsure about.
+func TestALPN_OpenSSLServer_SNISwapCtx(t *testing.T) {
+	// h2Ctx is the vhost selected by SNI; it prefers "h2".
+	newSwapServer := func(t *testing.T, sniName string, configureVhost func(*Ctx)) (*Conn, net.Conn, net.Conn) {
+		serverConn, clientConn := NetPipe(t)
+
+		defaultCtx := openSSLCtxALPN(t, nil)
+		if err := defaultCtx.SetServerALPNProtos([]string{"http/1.1"}); err != nil {
+			t.Fatal(err)
+		}
+		vhostCtx := openSSLCtxALPN(t, nil)
+		configureVhost(vhostCtx)
+
+		defaultCtx.SetTLSExtServernameCallback(func(ssl *SSL) SSLTLSExtErr {
+			if ssl.GetServername() == sniName {
+				ssl.SetSSLCtx(vhostCtx)
+			}
+			return SSLTLSExtErrOK
+		})
+
+		server, err := Server(serverConn, defaultCtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return server, serverConn, clientConn
+	}
+
+	// The swapped-in vhost configured ALPN, so its protocol ("h2") is selected
+	// even though the default listening Ctx would have picked "http/1.1".
+	t.Run("swapped ctx selects its own protocol", func(t *testing.T) {
+		server, serverConn, clientConn := newSwapServer(t, "h2.example", func(c *Ctx) {
+			if err := c.SetServerALPNProtos([]string{"h2"}); err != nil {
+				t.Fatal(err)
+			}
+		})
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		cfg := stdlibConfigALPN(t, []string{"h2", "http/1.1"})
+		cfg.ServerName = "h2.example"
+		client := tls.Client(clientConn, cfg)
+		defer close_both(server, client)
+
+		handshakeBoth(t, server, client)
+
+		got := client.ConnectionState().NegotiatedProtocol
+		t.Logf("SNI h2.example -> client NegotiatedProtocol=%q", got)
+		if got != "h2" {
+			t.Errorf("SNI-swapped Ctx ALPN not applied: negotiated %q, want %q "+
+				"(http/1.1 would mean the original Ctx did the selecting)", got, "h2")
+		}
+		if srv := server.GetALPNNegotiated(); srv != "h2" {
+			t.Errorf("server-side GetALPNNegotiated() = %q, want %q", srv, "h2")
+		}
+	})
+
+	// The swapped-in vhost did NOT configure server-side ALPN, so it opts out of
+	// selection entirely: the default Ctx's protocols are not leaked to it, and
+	// the handshake completes with no negotiated protocol.
+	t.Run("swapped ctx without ALPN opts out", func(t *testing.T) {
+		server, serverConn, clientConn := newSwapServer(t, "plain.example", func(c *Ctx) {})
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		cfg := stdlibConfigALPN(t, []string{"h2", "http/1.1"})
+		cfg.ServerName = "plain.example"
+		client := tls.Client(clientConn, cfg)
+		defer close_both(server, client)
+
+		handshakeBoth(t, server, client)
+
+		got := client.ConnectionState().NegotiatedProtocol
+		t.Logf("SNI plain.example (vhost without ALPN) -> client NegotiatedProtocol=%q", got)
+		if got != "" {
+			t.Errorf("vhost without ALPN negotiated %q, want %q "+
+				"(the default Ctx's protocols must not leak into the swapped vhost)", got, "")
+		}
+	})
+}
+
+// SetServerALPNProtos must snapshot its argument. Mutating the caller's slice
+// after the call must not change what the server negotiates: if the mutation
+// below leaked into the stored list, the server would look for "http/1.1" (which
+// the client does not offer) and abort instead of selecting "h2".
+func TestALPN_SetServerALPNProtos_CopiesSlice(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverCtx := openSSLCtxALPN(t, nil)
+	protos := []string{"h2"}
+	if err := serverCtx.SetServerALPNProtos(protos); err != nil {
+		t.Fatal(err)
+	}
+	protos[0] = "http/1.1" // Must not affect the server's stored copy.
+
+	server, err := Server(serverConn, serverCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := tls.Client(clientConn, stdlibConfigALPN(t, []string{"h2"}))
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	got := client.ConnectionState().NegotiatedProtocol
+	t.Logf("post-mutation client NegotiatedProtocol=%q", got)
+	if got != "h2" {
+		t.Errorf("server aliased caller's slice: client negotiated %q, want %q", got, "h2")
+	}
+}
+
+// Calling SetServerALPNProtos again must replace the previous list (and free the
+// old ctx-owned buffer). The most recent configuration governs negotiation.
+func TestALPN_SetServerALPNProtos_Rebind(t *testing.T) {
+	serverConn, clientConn := NetPipe(t)
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverCtx := openSSLCtxALPN(t, nil)
+	if err := serverCtx.SetServerALPNProtos([]string{"http/1.1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := serverCtx.SetServerALPNProtos([]string{"h2"}); err != nil {
+		t.Fatal(err)
+	}
+	server, err := Server(serverConn, serverCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := tls.Client(clientConn, stdlibConfigALPN(t, []string{"h2"}))
+	defer close_both(server, client)
+
+	handshakeBoth(t, server, client)
+
+	if got := client.ConnectionState().NegotiatedProtocol; got != "h2" {
+		t.Errorf("client negotiated %q, want %q (the second SetServerALPNProtos must win)", got, "h2")
+	}
+}

--- a/ctx.go
+++ b/ctx.go
@@ -34,6 +34,11 @@ import (
 var (
 	ssl_ctx_idx = C.X_SSL_CTX_new_index()
 
+	// alpn_protos_idx is the SSL_CTX ex_data index under which the server-side
+	// ALPN preference list is stored; allocating it here (package init) ensures
+	// it exists before any SetServerALPNProtos call or handshake.
+	_ = C.X_SSL_CTX_alpn_protos_new_index()
+
 	logger = spacelog.GetLogger()
 )
 
@@ -577,6 +582,52 @@ func (c *Ctx) SetNextProtos(protos []string) error {
 		C.uint(len(vector))))
 	if ret != 0 {
 		return errors.New("error while setting protos to ctx")
+	}
+	return nil
+}
+
+// SetServerALPNProtos enables server-side ALPN protocol selection. protos is the
+// server's ordered preference list; during the TLS handshake a protocol common
+// to the client's offer and this list is selected and echoed back in the
+// ServerHello. If the client and server share no protocol, the handshake is
+// aborted with a no_application_protocol alert (RFC 7301).
+//
+// Selection is performed by OpenSSL's SSL_select_next_proto and favors this
+// list's order: the first protocol here that the client also advertised is
+// chosen (server preference). Read the result with Conn.GetALPNNegotiated after
+// the handshake.
+//
+// This is what a server must call to negotiate a specific protocol such as "h2"
+// for gRPC/HTTP2. It differs from SetNextProtos, which only sets the client-side
+// advertised list (SSL_CTX_set_alpn_protos) and has no effect on server-side
+// selection.
+//
+// protos must be non-empty: enabling server-side selection with an empty list
+// would abort every handshake in which the client offers ALPN (the callback
+// finds no protocol to select and sends a no_application_protocol alert). To
+// leave server-side ALPN unconfigured, simply do not call this method.
+func (c *Ctx) SetServerALPNProtos(protos []string) error {
+	if len(protos) == 0 {
+		return errors.New("protos must be non-empty")
+	}
+	// Encode the preference list in ALPN wire format: each protocol prefixed by
+	// its 1-byte length. This is the encoding SSL_select_next_proto expects.
+	wire := make([]byte, 0)
+	for _, proto := range protos {
+		if len(proto) == 0 || len(proto) > 255 {
+			return fmt.Errorf(
+				"invalid ALPN proto %q: length must be between 1 and 255, got %d",
+				proto, len(proto))
+		}
+		wire = append(wire, byte(len(proto)))
+		wire = append(wire, proto...)
+	}
+	// X_SSL_CTX_set_server_alpn copies wire into ctx-owned (OpenSSL-freed) memory,
+	// so the caller's slice is never aliased and the stored copy outlives every
+	// handshake that reads it.
+	if C.X_SSL_CTX_set_server_alpn(c.ctx,
+		(*C.uchar)(unsafe.Pointer(&wire[0])), C.uint(len(wire))) != 1 {
+		return errors.New("failed to configure server ALPN")
 	}
 	return nil
 }

--- a/shim.h
+++ b/shim.h
@@ -99,6 +99,9 @@ extern int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
         EVP_CIPHER_CTX *cctx, HMAC_CTX *hctx, int enc);
 extern int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
                              unsigned int protos_len);
+extern int X_SSL_CTX_alpn_protos_new_index();
+extern int X_SSL_CTX_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                             unsigned int protos_len);
 
 /* BIO methods */
 extern int X_BIO_get_flags(BIO *b);

--- a/ssl.go
+++ b/ssl.go
@@ -75,6 +75,22 @@ func (s *SSL) GetServername() string {
 	return C.GoString(C.SSL_get_servername(s.ssl, C.TLSEXT_NAMETYPE_host_name))
 }
 
+// GetALPNNegotiated returns the application protocol selected via ALPN during
+// the handshake, or "" if none was negotiated (the peer offered no ALPN, or the
+// two sides shared no protocol). It is only meaningful after the handshake has
+// completed, and works on both client and server connections. This is how a
+// server reads the result of SetServerALPNProtos selection. Wraps
+// SSL_get0_alpn_selected.
+func (s *SSL) GetALPNNegotiated() string {
+	var data *C.uchar
+	var length C.uint
+	C.SSL_get0_alpn_selected(s.ssl, &data, &length)
+	if length == 0 {
+		return ""
+	}
+	return C.GoStringN((*C.char)(unsafe.Pointer(data)), C.int(length))
+}
+
 // GetOptions returns SSL options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (s *SSL) GetOptions() Options {


### PR DESCRIPTION
SetNextProtos wraps SSL_CTX_set_alpn_protos, which only sets the client-side list of protocols to advertise; on a server it has no effect on selection. As a result a server built on this library never echoed a negotiated protocol, and standard clients that enforce ALPN -- notably gRPC/HTTP2 clients requiring "h2" -- rejected the connection with a "missing selected ALPN property" error even though the TLS handshake otherwise completed.

Add Ctx.SetServerALPNProtos, which registers SSL_CTX_set_alpn_select_cb via a C thunk (mirroring the existing sni_cb wiring). The server's ordered preference list is stored on the Ctx; during the handshake the first protocol also advertised by the client is selected and echoed in the ServerHello. When there is no overlap the handshake is aborted with a no_application_protocol alert per RFC 7301.