### PR TITLE
build: add optional GOST engine static linking

### DIFF
--- a/.github/workflows/go-test-gost.yml
+++ b/.github/workflows/go-test-gost.yml
@@ -1,0 +1,96 @@
+name: Go Test GOST
+
+on: [push, pull_request]
+
+jobs:
+  gost:
+    runs-on: ubuntu-latest
+    name: GOST static (go 1.25.x)
+    env:
+      OPENSSL_VERSION: openssl-3.4.1
+      GOST_ENGINE_VERSION: v3.0.3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+
+      - name: Go information
+        run: |
+          go version
+          go env
+
+      - name: Cache OpenSSL static
+        id: cache-openssl
+        uses: actions/cache@v4
+        with:
+          path: /tmp/openssl-install
+          key: openssl-${{ env.OPENSSL_VERSION }}-static-v1
+
+      - name: Build OpenSSL static
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch ${{ env.OPENSSL_VERSION }} https://github.com/openssl/openssl.git /tmp/openssl-src
+          cd /tmp/openssl-src
+          ./config no-shared -fPIC --prefix=/tmp/openssl-install --openssldir=/etc/ssl
+          make -j$(nproc)
+          make install_sw
+
+      - name: Cache GOST engine static
+        id: cache-gost
+        uses: actions/cache@v4
+        with:
+          path: /tmp/gost-engine
+          key: gost-engine-${{ env.GOST_ENGINE_VERSION }}-static-v1
+
+      - name: Build GOST engine static
+        if: steps.cache-gost.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch ${{ env.GOST_ENGINE_VERSION }} --recursive https://github.com/gost-engine/engine.git /tmp/gost-engine
+          cd /tmp/gost-engine
+          sed -i 's/add_library(lib_gost_engine SHARED/add_library(lib_gost_engine STATIC/' CMakeLists.txt
+          sed -i '/install(TARGETS lib_gost_engine EXPORT/,/)/s/^/#disabled: /' CMakeLists.txt
+          mkdir build && cd build
+          cmake -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+                -DOPENSSL_ROOT_DIR=/tmp/openssl-install ..
+          cmake --build . --target lib_gost_engine gost_core gost_err
+
+      - name: Create gost-engine.pc
+        run: |
+          cat > /tmp/gost-engine.pc << 'PCEOF'
+          prefix=/tmp/gost-engine
+          build_dir=${prefix}/build
+
+          Name: gost-engine
+          Description: Reference implementation of GOST crypto algorithms for OpenSSL
+          Version: 3.0.3
+          Cflags: -I${prefix}
+          Libs: ${build_dir}/libgost.a ${build_dir}/libgost_core.a ${build_dir}/libgost_err.a
+          PCEOF
+
+      - name: Run tests (openssl_static openssl_gost)
+        env:
+          PKG_CONFIG_PATH: /tmp/openssl-install/lib64/pkgconfig:/tmp
+          CGO_ENABLED: 1
+        run: |
+          go test -v -tags "openssl_static openssl_gost" ./...
+
+      - name: Verify no dynamic deps on openssl or gost
+        env:
+          PKG_CONFIG_PATH: /tmp/openssl-install/lib64/pkgconfig:/tmp
+          CGO_ENABLED: 1
+        run: |
+          go test -tags "openssl_static openssl_gost" -c -o /tmp/test-binary .
+          echo "=== ldd output ==="
+          ldd /tmp/test-binary
+          echo "=== checking for libssl/libcrypto/gost ==="
+          if ldd /tmp/test-binary | grep -Ei 'libssl|libcrypto|gost'; then
+            echo "FAIL: dynamic dependency on openssl or gost found"
+            exit 1
+          else
+            echo "OK: no dynamic dependency on openssl or gost"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Optional static linking with the GOST engine for OpenSSL,
+  enabled with the `openssl_gost` build tag. When combined with static
+  GOST engine libraries (provided via `pkg-config`), Russian GOST
+  cryptographic algorithms (GOST 28147-89, Streebog, Kuznyechik, Magma,
+  etc.) become available through the standard `GetCipherByName` /
+  `GetDigestByName` API without any runtime engine loading. Requires
+  OpenSSL 3.0+.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Forked from https://github.com/libp2p/openssl (unmaintained) to add:
 3. Fix static build.
 4. Fix error extraction on key reading.
 5. Bindings for DANE.
+6. Optional static linking with GOST engine for Russian GOST crypto algorithms.
 
 ### License
 
@@ -34,3 +35,98 @@ limitations under the License.
 3. Build (or install precompiled) openssl for mingw32-w64
 4. Set __PKG\_CONFIG\_PATH__ to the directory containing openssl.pc
    (i.e. c:\mingw64\mingw64\lib\pkgconfig)
+
+### Static linking with GOST engine
+
+The library can optionally statically link the [GOST engine][gost-engine],
+which provides Russian GOST cryptographic algorithms (GOST 28147-89,
+Streebog, Kuznyechik, Magma, etc.). After linking, GOST ciphers and digests
+are available immediately through the standard `GetCipherByName` /
+`GetDigestByName` API — no runtime engine loading is needed.
+
+GOST engine requires OpenSSL 3.0+. The `openssl_gost` build tag can be used
+with or without `openssl_static`: static GOST libraries link against
+whichever OpenSSL (static or dynamic) is configured by the other build tags.
+
+#### Prerequisites
+
+Build OpenSSL (static, if using `openssl_static`) and GOST engine as static
+libraries:
+
+```bash
+# Build OpenSSL 3.4.1 static.
+git clone --depth 1 --branch openssl-3.4.1 https://github.com/openssl/openssl.git
+cd openssl
+./config no-shared -fPIC --prefix=$PWD/../openssl-install --openssldir=/etc/ssl
+make -j$(nproc) && make install_sw
+cd ..
+
+# Build GOST engine v3.0.3 static.
+git clone --depth 1 --branch v3.0.3 --recursive https://github.com/gost-engine/engine.git gost-engine
+cd gost-engine
+
+# GOST engine builds a shared library by default; switch it to static
+# and disable the install(EXPORT) that is incompatible with the static target.
+sed -i 's/add_library(lib_gost_engine SHARED/add_library(lib_gost_engine STATIC/' CMakeLists.txt
+sed -i '/install(TARGETS lib_gost_engine EXPORT/,/)/s/^/#disabled: /' CMakeLists.txt
+
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+      -DOPENSSL_ROOT_DIR=$PWD/../../openssl-install ..
+cmake --build . --target lib_gost_engine gost_core gost_err
+```
+
+#### Creating the pkg-config file
+
+The `openssl_gost` build tag uses `pkg-config` to find the GOST engine
+libraries, just like `openssl_static` uses it for OpenSSL. Create a
+`gost-engine.pc` file so pkg-config can locate the static libraries:
+
+```bash
+GOST=$PWD/..   # Path to the gost-engine directory (parent of build/).
+
+cat > /usr/local/lib/pkgconfig/gost-engine.pc << EOF
+prefix=$GOST
+build_dir=\${prefix}/build
+
+Name: gost-engine
+Description: Reference implementation of GOST crypto algorithms for OpenSSL
+Version: 3.0.3
+Cflags: -I\${prefix}
+Libs: \${build_dir}/libgost.a \${build_dir}/libgost_core.a \${build_dir}/libgost_err.a
+EOF
+```
+
+#### Building with GOST engine
+
+Use the `openssl_gost` build tag (optionally combined with `openssl_static`).
+No `CGO_LDFLAGS` is needed — pkg-config handles everything:
+
+```bash
+PKG_CONFIG_PATH=/path/to/openssl-install/lib64/pkgconfig \
+go build -tags "openssl_static openssl_gost" ./...
+```
+
+#### Using GOST algorithms
+
+After building with `openssl_gost`, GOST ciphers and digests are available
+through the standard API. The engine is loaded automatically during package
+initialization:
+
+```go
+import "github.com/tarantool/go-openssl"
+
+// GOST 28147-89 cipher.
+cipher, err := openssl.GetCipherByName("GOST 28147-89")
+
+// Streebog (GOST R 34.11-2012) digests.
+digest, err := openssl.GetDigestByName("streebog256")
+digest, err = openssl.GetDigestByName("streebog512")
+
+// Kuznyechik / Magma block ciphers.
+cipher, err := openssl.GetCipherByName("kuznyechik-cbc")
+cipher, err = openssl.GetCipherByName("magma-cbc")
+```
+
+[gost-engine]: https://github.com/gost-engine/engine

--- a/build_gost.go
+++ b/build_gost.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2026. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build openssl_gost
+// +build openssl_gost
+
+package openssl
+
+// #cgo CFLAGS: -DGOST_ENGINE_STATIC -Wno-deprecated-declarations
+// #cgo pkg-config: --static gost-engine
+import "C"

--- a/gost_test.go
+++ b/gost_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2026. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build openssl_gost
+// +build openssl_gost
+
+package openssl_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-openssl"
+)
+
+func TestGostCipherRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		cipher    string
+		plaintext string
+	}{
+		{"GOST28147", "GOST 28147-89", "The GOST cipher round-trip test"},
+		{"Kuznyechik", "kuznyechik-cbc", "Kuznyechik block cipher round-trip test"},
+		{"Magma", "magma-cbc", "Magma block cipher round-trip test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cipher, err := openssl.GetCipherByName(tt.cipher)
+			require.NoError(t, err)
+			require.NotNil(t, cipher)
+
+			key := bytes.Repeat([]byte{0x01}, cipher.KeySize())
+			iv := bytes.Repeat([]byte{0x02}, cipher.IVSize())
+			plaintext := []byte(tt.plaintext)
+
+			encCtx, err := openssl.NewEncryptionCipherCtx(cipher, nil, key, iv)
+			require.NoError(t, err)
+
+			ciphertext, err := encCtx.EncryptUpdate(plaintext)
+			require.NoError(t, err)
+
+			final, err := encCtx.EncryptFinal()
+			require.NoError(t, err)
+			ciphertext = append(ciphertext, final...)
+
+			decCtx, err := openssl.NewDecryptionCipherCtx(cipher, nil, key, iv)
+			require.NoError(t, err)
+
+			decrypted, err := decCtx.DecryptUpdate(ciphertext)
+			require.NoError(t, err)
+
+			finalDec, err := decCtx.DecryptFinal()
+			require.NoError(t, err)
+			decrypted = append(decrypted, finalDec...)
+
+			require.Equal(t, plaintext, decrypted)
+		})
+	}
+}

--- a/shim.c
+++ b/shim.c
@@ -372,6 +372,10 @@ int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CI
  ************************************************
  */
 
+#ifdef GOST_ENGINE_STATIC
+extern void ENGINE_load_gost(void);
+#endif
+
 int X_shim_init() {
 	int rc = 0;
 
@@ -380,6 +384,16 @@ int X_shim_init() {
 	SSL_load_error_strings();
 	SSL_library_init();
 	OpenSSL_add_all_algorithms();
+#ifdef GOST_ENGINE_STATIC
+	ENGINE_load_gost();
+	{
+		ENGINE *e = ENGINE_by_id("gost");
+		if (e == NULL) {
+			return -1;
+		}
+		ENGINE_free(e);
+	}
+#endif
 	//
 	// Set up OPENSSL thread safety callbacks.
 	rc = go_init_locks();


### PR DESCRIPTION
The static-linked library had no support for Russian GOST cryptographic algorithms (GOST 28147-89, Streebog, Kuznyechik, Magma).

The new `openssl_gost` build tag statically links the gost-engine [1] and calls ENGINE_load_gost() during initialization, making all GOST ciphers and digests available through the existing GetCipherByName and GetDigestByName API with no runtime engine loading.

The tag works with both `openssl_static` and dynamic OpenSSL. GOST libraries are discovered via pkg-config, consistent with how `openssl_static` discovers OpenSSL.

1. https://github.com/gost-engine/engine